### PR TITLE
Generalise rates and beggar protocol

### DIFF
--- a/src/proto/lpms.proto
+++ b/src/proto/lpms.proto
@@ -70,7 +70,6 @@ message DayOfWeekLOSRule {
 // TODO: Allow change in rates based on adult / child pricing.
 message Rates {
   uint32 cost = 1;
-  uint32 includedOccupancy = 2;
 }
 
 message DayOfWeekRateModifierElement {

--- a/src/proto/seed.proto
+++ b/src/proto/seed.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
 message Beg {
-  // videre line that we are begging to be whitelisted on
-  bytes line = 1;
-  // signature of the begger
+  // what the beggar is begging for
+  bytes what = 1;
+  // signature of the beggar
   bytes signature = 2;
 }


### PR DESCRIPTION
This PR:

1. Generalises the `Rates` protobuf so that it may be used both for `space` and for `otherItem`.
2. Generalises the `Beg` protobuf (to be used for wallet seeding / airdrop claiming etc).